### PR TITLE
Rename plugin artifact to avoid collision

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </license>
   </licenses>
 
-  <artifactId>gerrit</artifactId>
+  <artifactId>gerrit-code-review</artifactId>
   <version>0.1.1</version>
   <packaging>hpi</packaging>
   <name>Gerrit Code Review plugin</name>


### PR DESCRIPTION
Avoids clashing with older plugin named gerrit.
See https://github.com/jenkins-infra/repository-permissions-updater/pull/641#issuecomment-375648780